### PR TITLE
Update SetWhoToUI flag

### DIFF
--- a/GuildInviter/GuildInviter.lua
+++ b/GuildInviter/GuildInviter.lua
@@ -143,7 +143,8 @@ function GI:DoSearch(isManualOverride)
     end
 
     self:UpdateStatusText("SCANNING", self.currentScanLevel)
-    SetWhoToUI(true)
+    -- Display /who results directly in the chat rather than the UI
+    SetWhoToUI(false)
     SendWho("g-\"\" " .. self.currentScanLevel)
     self.currentScanLevel = self.currentScanLevel + 1
 end


### PR DESCRIPTION
## Summary
- prevent WHO results from populating the UI

## Testing
- `luac -p GuildInviter/GuildInviter.lua`

------
https://chatgpt.com/codex/tasks/task_b_687bb2c4d74c8324a5231acdd4479b1e